### PR TITLE
Fix LobbyViewModel lifecycle handling

### DIFF
--- a/lib/presentation/screens/reconnect_screen.dart
+++ b/lib/presentation/screens/reconnect_screen.dart
@@ -23,10 +23,10 @@ class _ReconnectScreenState extends State<ReconnectScreen> {
   @override
   void initState() {
     super.initState();
-    // Kein _checkReconnect(ref) hier, da ref nur im Consumer verfügbar ist
+    // _checkReconnect wird in build() ausgelöst
   }
 
-  Future<void> _checkReconnect(WidgetRef ref) async {
+  Future<void> _checkReconnect() async {
     try {
       final deviceId = await DeviceIdHelper.getSafeDeviceId();
       final reconnectData = await _reconnectService.getReconnectData(deviceId);
@@ -45,7 +45,7 @@ class _ReconnectScreenState extends State<ReconnectScreen> {
         );
         if (!mounted) return;
         if (result == true) {
-          final viewModel = LobbyViewModel(ref: ref);
+          final viewModel = LobbyViewModel();
           await viewModel.handleReconnect(context, reconnectData);
         } else {
           await _reconnectService.clearReconnectData(deviceId);
@@ -72,7 +72,7 @@ class _ReconnectScreenState extends State<ReconnectScreen> {
         if (_isLoading) {
           // Starte den Reconnect-Check nur einmal
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (_isLoading) _checkReconnect(ref);
+            if (_isLoading) _checkReconnect();
           });
         }
         return Scaffold(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -13,6 +13,7 @@ import 'package:jugend_app/presentation/screens/game_settings_screen.dart';
 import 'package:jugend_app/domain/viewmodels/lobby_view_model.dart';
 import 'package:jugend_app/data/repositories/lobby_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart' as p;
 import 'package:jugend_app/presentation/screens/feedback_screen.dart';
 import 'package:jugend_app/presentation/screens/games_catalog_screen.dart';
 import 'package:jugend_app/presentation/screens/game_detail_screen.dart';
@@ -81,27 +82,14 @@ final GoRouter appRouter = GoRouter(
       path: '/lobby',
       pageBuilder: (context, state) {
         final data = state.extra as ReconnectData;
+        final viewModel = LobbyViewModel(lobbyRepository: LobbyRepository());
         return _fadeTransitionPage(
-          riverpod.Consumer(
-            builder: (context, ref, _) {
-              final viewModel = LobbyViewModel(
-                ref: ref,
-                lobbyRepository: LobbyRepository(),
-              );
-              viewModel.initialize(
-                lobbyId: data.lobbyId,
-                playerName: data.playerName,
-                isHost: data.isHost,
-                gameType: data.gameType,
-              );
-              return LobbyScreen(
-                lobbyId: data.lobbyId,
-                playerName: data.playerName,
-                isHost: data.isHost,
-                gameType: data.gameType,
-                viewModel: viewModel,
-              );
-            },
+          LobbyScreen(
+            lobbyId: data.lobbyId,
+            playerName: data.playerName,
+            isHost: data.isHost,
+            gameType: data.gameType,
+            viewModel: viewModel,
           ),
         );
       },
@@ -109,26 +97,14 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/game',
       pageBuilder: (context, state) {
-        final data = state.extra;
-        if (data is! ReconnectData) {
-          // Fallback: Weiterleitung auf Startseite
+        final extra = state.extra;
+        if (extra is! LobbyViewModel) {
           return _fadeTransitionPage(const HomeScreen());
         }
         return _fadeTransitionPage(
-          riverpod.Consumer(
-            builder: (context, ref, _) {
-              final viewModel = LobbyViewModel(
-                ref: ref,
-                lobbyRepository: LobbyRepository(),
-              );
-              viewModel.initialize(
-                lobbyId: data.lobbyId,
-                playerName: data.playerName,
-                isHost: data.isHost,
-                gameType: data.gameType,
-              );
-              return const GameScreen();
-            },
+          p.ChangeNotifierProvider.value(
+            value: extra,
+            child: const GameScreen(),
           ),
         );
       },
@@ -136,25 +112,14 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/game-settings',
       pageBuilder: (context, state) {
-        final data = state.extra;
-        if (data is! ReconnectData) {
+        final extra = state.extra;
+        if (extra is! LobbyViewModel) {
           return _fadeTransitionPage(const HomeScreen());
         }
         return _fadeTransitionPage(
-          riverpod.Consumer(
-            builder: (context, ref, _) {
-              final viewModel = LobbyViewModel(
-                ref: ref,
-                lobbyRepository: LobbyRepository(),
-              );
-              viewModel.initialize(
-                lobbyId: data.lobbyId,
-                playerName: data.playerName,
-                isHost: data.isHost,
-                gameType: data.gameType,
-              );
-              return const GameSettingsScreen();
-            },
+          p.ChangeNotifierProvider.value(
+            value: extra,
+            child: const GameSettingsScreen(),
           ),
         );
       },


### PR DESCRIPTION
## Summary
- keep a single LobbyViewModel instance alive using ChangeNotifierProvider.value
- revert LobbyViewModel to not require WidgetRef and route using the existing instance
- adjust reconnect workflow and routing to hand off the same model

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841763d8fd08324b7f01ace76195d91